### PR TITLE
Replace parseFloat with safer Number cast

### DIFF
--- a/src/io/sb3/fromSb3.ts
+++ b/src/io/sb3/fromSb3.ts
@@ -111,7 +111,7 @@ function getBlockScript(blocks: { [key: string]: sb3.Block }) {
                   if (typeof value !== "string") {
                     return value;
                   }
-                  const asNum = parseFloat(value);
+                  const asNum = Number(value);
                   if (!isNaN(asNum)) {
                     return asNum;
                   }
@@ -177,14 +177,15 @@ function getBlockScript(blocks: { [key: string]: sb3.Block }) {
             case BIS.WHOLE_NUM_PRIMITIVE:
             case BIS.INTEGER_NUM_PRIMITIVE: {
               let storedValue: string | number = value[1];
-              if (!isNaN(parseFloat(storedValue as string))) {
-                storedValue = parseFloat(storedValue as string);
+              const asNum = Number(storedValue as string);
+              if (!isNaN(asNum)) {
+                storedValue = asNum;
               }
               addInput(inputName, { type: "number", value: storedValue });
               break;
             }
             case BIS.ANGLE_NUM_PRIMITIVE:
-              addInput(inputName, { type: "angle", value: parseFloat(value[1] as string) });
+              addInput(inputName, { type: "angle", value: Number(value[1] as string) });
               break;
             case BIS.COLOR_PICKER_PRIMITIVE:
               addInput(inputName, {
@@ -241,8 +242,9 @@ function getBlockScript(blocks: { [key: string]: sb3.Block }) {
                 return { type: "string", value: null };
               }
               if (typeof value.value === "string") {
-                if (!isNaN(parseFloat(value.value))) {
-                  value.value = parseFloat(value.value);
+                const asNum = Number(value.value);
+                if (!isNaN(asNum)) {
+                  value.value = asNum;
                 }
               }
               return value;


### PR DESCRIPTION
`parseFloat` will parse a value like `"1x"` as `1`. This means that `isNaN(parseFloat(...))` cannot be reliably used to tell whether a value is a number.

Currently, sb-edit will turn this:
![image](https://user-images.githubusercontent.com/25993062/75611664-847f3e00-5aea-11ea-8695-63cdc1a4d469.png)
into this:
![image](https://user-images.githubusercontent.com/25993062/75611670-8ba64c00-5aea-11ea-969b-bd0824db01c5.png)

A `Number` cast will not perform any such shenanigans.

EDIT: this will also properly parse hex literals as numbers.